### PR TITLE
Add support for CloudFormation YAML intrinsic shorthands

### DIFF
--- a/bin/regentanz
+++ b/bin/regentanz
@@ -2,6 +2,8 @@
 
 $LOAD_PATH << File.expand_path('../../lib', __FILE__)
 
+require 'regentanz/yaml-ext'
+
 case ARGV.first
 when 'compare'
   ARGV.shift

--- a/lib/regentanz/template_compiler.rb
+++ b/lib/regentanz/template_compiler.rb
@@ -119,6 +119,20 @@ module Regentanz
       end
     end
 
+    YAML.add_domain_type('regentanz', 'GetAtt') do |_, value|
+      {'Fn::GetAtt' => value.to_s.split('.')}
+    end
+    %w[Ref ResolveRef].each do |name|
+      YAML.add_domain_type('regentanz', name) do |tag, value|
+        {name => value}
+      end
+    end
+    %w[FindInMap GetAZs ImportValue Join Select Split Sub].each do |name|
+      YAML.add_domain_type('regentanz', name) do |tag, value|
+        {['Fn', name].join('::') => value}
+      end
+    end
+
     def load(path)
       YAML.load_file(path)
     rescue Psych::SyntaxError => e

--- a/lib/regentanz/template_compiler.rb
+++ b/lib/regentanz/template_compiler.rb
@@ -119,20 +119,6 @@ module Regentanz
       end
     end
 
-    YAML.add_domain_type('regentanz', 'GetAtt') do |_, value|
-      {'Fn::GetAtt' => value.to_s.split('.')}
-    end
-    %w[Ref ResolveRef].each do |name|
-      YAML.add_domain_type('regentanz', name) do |tag, value|
-        {name => value}
-      end
-    end
-    %w[FindInMap GetAZs ImportValue Join Select Split Sub].each do |name|
-      YAML.add_domain_type('regentanz', name) do |tag, value|
-        {['Fn', name].join('::') => value}
-      end
-    end
-
     def load(path)
       YAML.load_file(path)
     rescue Psych::SyntaxError => e

--- a/lib/regentanz/yaml-ext.rb
+++ b/lib/regentanz/yaml-ext.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require 'yaml'
+
+module YAML
+  add_domain_type('regentanz', 'GetAtt') do |_, value|
+    {'Fn::GetAtt' => value.to_s.split('.')}
+  end
+  %w[Ref ResolveRef].each do |name|
+    add_domain_type('regentanz', name) do |tag, value|
+      {name => value}
+    end
+  end
+  %w[FindInMap GetAZs ImportValue Join Select Split Sub].each do |name|
+    add_domain_type('regentanz', name) do |tag, value|
+      {['Fn', name].join('::') => value}
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,2 @@
 require 'regentanz'
+require 'regentanz/yaml-ext'


### PR DESCRIPTION
In the standard support for YAML, the intrinsic functions can be written using YAML tags instead of using the traditional map-based approach.

Given that the shorthand is limited to the YAML format, it doesn't seem to add much value, as it only saves a few keystrokes per invocation, but it would make sense to be able to bring your existing YAML files into the tool.

This injects these tag handlers globally, which doesn't work well when using the code as a library, but there doesn't seem to be any real alternative using the standard library YAML/Psych. From that perspective it would arguably be nicer to move these registrations to a separate file, but I'm not sure using the code as a library has much value at this point, and thus I'm not sure it is worth the extra effort.