### PR TITLE
Generalize the S3 location used for validating large templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,25 @@ To compile a template you use the `regentanz` command like this:
 $ regentanz compile path/to/template > path/to/compiled/template.json
 ```
 
+### Template validation
+
 The compiler will validate the final template with CloudFormation, so you will need to run it with AWS credentials that permit `cloudformation:ValidateTemplate`.
+
+For the validation to work with templates larger than 51200 bytes you need to specify an S3 bucket in a config file, and need AWS credentials that permit `s3:PutObject` in that bucket.
+
+To configure a bucket to use for validation of large templates create a file called `.regentanz.yml` in the directory where you will run Regentanz, and add the following:
+
+```yaml
+template_url: 's3://some-bucket-name/a_prefix/${TEMPLATE_NAME}.json'
+```
+
+You can use `${AWS_REGION}` in the bucket portion, and `${TEMPLATE_NAME}` and `${TIMESTAMP}` in the key portion to create unique URLs. You can, for example, use the buckets that CloudFormation creates for template uploads, like this:
+
+```yaml
+template_url: 's3://cf-templates-xyz-${AWS_REGION}/regentanz/${TEMPLATE_NAME}-${TIMESTAMP}.json'
+```
+
+Where "xyz" is the unique letter combination for your account.
 
 ### Anatomy of a template
 

--- a/examples/.regentanz.yml
+++ b/examples/.regentanz.yml
@@ -1,2 +1,3 @@
 load_path:
   - lib
+default_region: us-east-1

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,7 @@ Use the `compile` command to compile the `super_duper` template into CloudFormat
 $ ../bin/regentanz compile templates/super_duper > build/super_duper.json
 ```
 
-The compiler uses the CloudFormation API to validate the template so you will need to either have the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables set, or any of the other standard ways of configuring the AWS SDK with credentials.
+The compiler uses the CloudFormation API to validate the template so you will need to either have the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_DEFAULT_REGION` environment variables set, or any of the other standard ways of configuring the AWS SDK with credentials.
 
 ### Template contents
 

--- a/lib/regentanz/cli/common.rb
+++ b/lib/regentanz/cli/common.rb
@@ -13,6 +13,10 @@ module Regentanz
               $LOAD_PATH << File.absolute_path(extra_load_path, File.dirname(path))
             end
           end
+          if config['default_region'].nil? && (region = ENV['AWS_REGION'] || ENV['AWS_DEFAULT_REGION'])
+            config['default_region'] = region
+          end
+          config
         end
       end
 

--- a/lib/regentanz/cli/compile.rb
+++ b/lib/regentanz/cli/compile.rb
@@ -6,19 +6,16 @@ module Regentanz
     class Compile
       include Common
 
-      def initialize
-        @compiler = Regentanz::TemplateCompiler.new
-      end
-
       def run(args)
-        load_config
+        config = load_config
         stack_path = args.first
-        template = @compiler.compile_from_path(stack_path)
+        compiler = Regentanz::TemplateCompiler.new(config)
+        template = compiler.compile_from_path(stack_path)
         template_json = JSON.pretty_generate(template)
         if template_json.bytesize >= 51200
           template_json = JSON.generate(template)
         end
-        @compiler.validate_template(stack_path, template_json)
+        compiler.validate_template(stack_path, template_json)
         puts(template_json)
         0
       rescue Regentanz::Error => e

--- a/lib/regentanz/template_compiler.rb
+++ b/lib/regentanz/template_compiler.rb
@@ -74,10 +74,10 @@ module Regentanz
       if @template_url
         if (captures = @template_url.match(%r{\As3://(?<bucket>[^/]+)/(?<key>.+)\z}))
           bucket = captures[:bucket]
-          bucket = bucket.sub('${AWS_REGION}', @region)
+          bucket = bucket.gsub('${AWS_REGION}', @region)
           key = captures[:key]
-          key = key.sub('${TEMPLATE_NAME}', File.basename(stack_path))
-          key = key.sub('${TIMESTAMP}', Time.now.to_i.to_s)
+          key = key.gsub('${TEMPLATE_NAME}', File.basename(stack_path))
+          key = key.gsub('${TIMESTAMP}', Time.now.to_i.to_s)
           obj = @s3_client.bucket(bucket).object(key)
           obj.put(body: template)
           obj.public_url

--- a/lib/regentanz/template_compiler.rb
+++ b/lib/regentanz/template_compiler.rb
@@ -6,9 +6,9 @@ module Regentanz
     CredentialsError = Class.new(Regentanz::Error)
     TemplateError = Class.new(Regentanz::Error)
 
-    def initialize(cloud_formation_client: nil, s3_client: nil)
+    def initialize(config, cloud_formation_client: nil, s3_client: nil)
       @resource_compilers = {}
-      @region = ENV.fetch('AWS_REGION', 'eu-west-1')
+      @region = config['default_region']
       @cf_client = cloud_formation_client || Aws::CloudFormation::Client.new(region: @region)
       @s3_client = s3_client || Aws::S3::Resource.new(region: @region)
     rescue Aws::Sigv4::Errors::MissingCredentialsError => e

--- a/spec/regentanz/template_compiler_spec.rb
+++ b/spec/regentanz/template_compiler_spec.rb
@@ -631,7 +631,7 @@ module Regentanz
 
         context 'and the template URL contains variables' do
           let :config do
-            super().merge('template_url' => 's3://templates-${AWS_REGION}/some/prefix/${TEMPLATE_NAME}-${TIMESTAMP}.json')
+            super().merge('template_url' => 's3://templates-${AWS_REGION}/some/prefix/${TEMPLATE_NAME}/${TEMPLATE_NAME}-${TIMESTAMP}.json')
           end
 
           before do
@@ -646,7 +646,7 @@ module Regentanz
 
           it 'replaces ${TEMPLATE_NAME} in the key with the directory name of the template' do
             compiler.validate_template('some/path/to/a/template/called/foobar', large_template)
-            expect(bucket).to have_received(:object).with(start_with('some/prefix/foobar-'))
+            expect(bucket).to have_received(:object).with(start_with('some/prefix/foobar/foobar-'))
           end
 
           it 'replaces ${TIMESTAMP} in the key with current time as a UNIX timestamp' do

--- a/spec/regentanz/template_compiler_spec.rb
+++ b/spec/regentanz/template_compiler_spec.rb
@@ -30,7 +30,13 @@ module Regentanz
 
   describe TemplateCompiler do
     let :compiler do
-      described_class.new(cloud_formation_client: cf_client, s3_client: s3_client)
+      described_class.new(config, cloud_formation_client: cf_client, s3_client: s3_client)
+    end
+
+    let :config do
+      {
+        'default_region' => 'ap-southeast-1',
+      }
     end
 
     let :cf_client do
@@ -619,26 +625,9 @@ module Regentanz
           expect(cf_client).to have_received(:validate_template).with(template_url: 's3-url').ordered
         end
 
-        it 'uploads the template to a bucket in the default region' do
+        it 'uploads the template to a bucket in the configured region' do
           compiler.validate_template('stack', large_template)
-          expect(s3_client).to have_received(:bucket).with('cf-templates-jn3m2hocei1o-eu-west-1')
-        end
-
-        context 'when a region has been configured with the AWS_REGION environment variable' do
-          around do |example|
-            original_region = ENV['AWS_REGION']
-            ENV['AWS_REGION'] = 'ap-southeast-1'
-            begin
-              example.call
-            ensure
-              ENV['AWS_REGION'] = original_region
-            end
-          end
-
-          it 'uploads the template to a bucket in that region' do
-            compiler.validate_template('stack', large_template)
-            expect(s3_client).to have_received(:bucket).with('cf-templates-jn3m2hocei1o-ap-southeast-1')
-          end
+          expect(s3_client).to have_received(:bucket).with('cf-templates-jn3m2hocei1o-ap-southeast-1')
         end
       end
 


### PR DESCRIPTION
I had forgotten to remove our hard coded CloudFormation S3 bucket from the code, and it bugged me, so I rewrote things to enable the location of the uploaded template to be configurable.